### PR TITLE
Match Decorator Test Cases

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -4,14 +4,100 @@ test_parsing.py
 Tests the X12 base parse module
 """
 import pytest
+from typing import Dict
+from x12.parsing import X12SegmentParser, match
+from x12.transactions.x12_270_005010X279A1.parsing import EligibilityInquiryParser
 
-from x12.parsing import X12SegmentParser
-from x12.transactions.x12_270_005010X279A1.parse import EligibilityInquiryParser
+
+@pytest.fixture
+def segment_data(x12_delimiters) -> Dict[str, str]:
+    """
+    The segment_data fixture represents a "parsed" segment from a X12 stream.
+    Streams are list of values which are "parsed" into a dictionary with field names.
+    """
+    return {
+        "delimiters": x12_delimiters.dict(),
+        "segment_name": "ST",
+        "transaction_set_identifier_code": "270",
+        "transaction_set_control_number": "0001",
+        "implementation_convention_reference": "005010X279A1",
+    }
+
+
+@pytest.fixture
+def data_context():
+    """
+    The data_context fixture is a stub or placeholder for the parsing function.
+    """
+    return {}
+
+
+@pytest.fixture
+def data_record():
+    """
+    The data_record fixture is the parsing "target" for the parsing function.
+    """
+    return {"header": {"st_segment": None}}
+
+
+@pytest.fixture
+def mock_parsing_function():
+    """
+    The mock parsing fixture is a function which will parse segment_data into a data_record.
+    """
+
+    def parse_st_segment(segment_data, data_context, data_record):
+        data_record["header"]["st_segment"] = segment_data
+
+    return parse_st_segment
+
+
+def test_match_no_conditions(
+    mock_parsing_function, segment_data, data_context, data_record
+):
+    """
+    Tests the match decorator when no conditions are specified.
+    """
+    wrapped_func = match("ST")(mock_parsing_function)
+    wrapped_func(segment_data, data_context, data_record)
+    assert data_record["header"]["st_segment"] == segment_data
+
+
+def test_match_conditions(
+    mock_parsing_function, segment_data, data_context, data_record
+):
+    """
+    Tests the match decorator when conditions are specified.
+    """
+    wrapped_func = match("ST", conditions={"transaction_set_identifier_code": "270"})(
+        mock_parsing_function
+    )
+    wrapped_func(segment_data, data_context, data_record)
+    assert data_record["header"]["st_segment"] == segment_data
+
+
+def test_match_conditions_unmatched(
+    mock_parsing_function, segment_data, data_context, data_record
+):
+    """
+    Tests the match decorator when conditions are specified but they do not match the data_segment.
+    """
+    wrapped_func = match("ST", conditions={"transaction_set_identifier_code": "911"})(
+        mock_parsing_function
+    )
+    wrapped_func(segment_data, data_context, data_record)
+    assert data_record["header"]["st_segment"] is None
 
 
 def test_load_parser():
+    """
+    Tests the parser load process and validates the segment_parser dictionary which contains parsing functions.
+    """
     parser = X12SegmentParser.load_parser("270", "005010X279A1")
     assert isinstance(parser, EligibilityInquiryParser)
+    assert len(EligibilityInquiryParser.segment_parsers) > 1
+    assert "ST" in EligibilityInquiryParser.segment_parsers
+    assert "SE" in EligibilityInquiryParser.segment_parsers
 
     with pytest.raises(ModuleNotFoundError):
         X12SegmentParser.load_parser("911", "bad-bad-version")

--- a/tests/x12_270_00510X279A1/test_eligibility_inquiry.py
+++ b/tests/x12_270_00510X279A1/test_eligibility_inquiry.py
@@ -1,7 +1,0 @@
-from x12.transactions.x12_270_005010X279A1.transaction_set import EligibilityInquiry
-
-
-def test_it():
-    for f in EligibilityInquiry.__fields__.values():
-        x = 1
-        print(f)

--- a/x12/parsing.py
+++ b/x12/parsing.py
@@ -75,8 +75,8 @@ class X12SegmentParser(ABC):
         :raises: ValueError if the transaction module exists, but a parser class cannot be found.
         """
         transaction_package: str = f"x12_{transaction_code}_{implementation_version}"
-        parser_package: str = f"x12.transactions.{transaction_package}.parse"
-        mod = import_module(parser_package)
+        parsing_package: str = f"x12.transactions.{transaction_package}.parsing"
+        mod = import_module(parsing_package)
 
         def load_segment_parsers() -> Dict[str, List[Callable]]:
             """Returns dictionary of Segment Name [Key], Segment Parsers [List]"""

--- a/x12/transactions/__init__.py
+++ b/x12/transactions/__init__.py
@@ -6,7 +6,7 @@ Transaction implementations are stored in separate packages with the following s
 
     x12_[transaction_code]_[implementation_version]
     / loops.py -Defines the loop models used within the transaction.
-    / parse.py - Defines the segment parsers used to build the transactional loops.
+    / parsing.py - Defines the segment parsers used to build the transactional loops.
     / segments.py - Contains the overriden/subclassed segments used to support the transactional specification.
     / transaction_set.py - The high level transaction set model which is returned by the model reader
 """

--- a/x12/transactions/x12_270_005010X279A1/parsing.py
+++ b/x12/transactions/x12_270_005010X279A1/parsing.py
@@ -1,5 +1,5 @@
 """
-parse.py
+parsing.py
 
 Defines the classes and functions used to parse X12 270 005010X279A1 segments into a transactional model.
 """
@@ -35,17 +35,11 @@ class EligibilityInquiryParser(X12SegmentParser):
     The 270 005010X279A1 parser.
     """
 
-    def __init__(self):
-        """
-        Configures the data record for the 270 transaction.
-        """
-        super().__init__()
-        self._data_record[EligibilityInquiryLoops.INFORMATION_SOURCE] = []
-
     def reset(self):
         """
         Resets the data record for the 270 transaction.
         """
+        super().reset()
         self._data_record[EligibilityInquiryLoops.INFORMATION_SOURCE] = []
 
     def load_model(self) -> X12SegmentGroup:


### PR DESCRIPTION
This PR adds test cases for the `@match` decorator which is used to match segment parsing functions to X12 segment streams.