### PR TITLE
X12ModelReader

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,3 +207,32 @@ def x12_270_dependent_input(
     x12_270_control_header, x12_270_dependent_transaction, x12_270_control_footer
 ) -> str:
     return f"{x12_270_control_header}{x12_270_dependent_transaction}{x12_270_control_footer}"
+
+
+@pytest.fixture
+def x12_with_custom_delimiters():
+    return "\n".join(
+        [
+            "ISA|03|9876543210|01|9876543210|30|000000005      |30|12345          |131031|1147|^|00501|000000907|1|T|:?",
+            "GS|HS|000000005|54321|20131031|1147|1|X|005010X279A1?",
+            "ST|270|0001|005010X279A1?",
+            "BHT|0022|13|10001234|20131031|1147?",
+            "HL|1||20|1?",
+            "NM1|PR|2|PAYER C|||||PI|12345?",
+            "HL|2|1|21|1?",
+            "NM1|1P|1|DOE|JOHN||||XX|1467857193?",
+            "REF|4A|000111222?",
+            "N3|123 MAIN ST.|SUITE 42?",
+            "N4|SAN MATEO|CA|94401?",
+            "HL|3|2|22|0?",
+            "TRN|1|930000000000|9800000004|PD?",
+            "NM1|IL|1|DOE|JOHN||||MI|00000000001?",
+            "REF|6P|0123456789?",
+            "DMG|D8|19700101?",
+            "DTP|291|D8|20131031?",
+            "EQ|30?",
+            "SE|17|0001?",
+            "GE|1|1?",
+            "IEA|1|000000907?",
+        ]
+    )

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -5,6 +5,7 @@ Tests the Pydantic X12 segment models
 """
 from x12.segments import *
 from decimal import Decimal
+from x12.models import X12Delimiters
 
 
 def test_amt_segment():
@@ -259,3 +260,21 @@ def test_segment_lookup():
     assert "ISA" in SEGMENT_LOOKUP
     assert "ST" in SEGMENT_LOOKUP
     assert "SE" in SEGMENT_LOOKUP
+
+
+def test_x12_with_custom_delimiters():
+    """tests x12 generation where custom delimiters are used"""
+    x12_delimiters: X12Delimiters = X12Delimiters(
+        element_separator="|", segment_terminator="?"
+    )
+
+    segment_data = {
+        "delimiters": x12_delimiters.dict(),
+        "trace_type_code": "1",
+        "reference_identification_1": "98175-012547",
+        "originating_company_identifier": "8877281234",
+        "reference_identification_2": "RADIOLOGY",
+    }
+
+    trn_segment: TrnSegment = TrnSegment(**segment_data)
+    assert trn_segment.x12() == "TRN|1|98175-012547|8877281234|RADIOLOGY?"

--- a/tests/test_x12_model_reader.py
+++ b/tests/test_x12_model_reader.py
@@ -16,3 +16,22 @@ def test_multiple_transactions(
         model_result = [m for m in r.models()]
         assert len(model_result) == 2
         assert model_result[0].x12() == x12_270_subscriber_transaction
+
+
+def test_custom_delimiters(x12_with_custom_delimiters):
+
+    # remove control segments from the x12 transaction with custom delimiters
+    control_segments = ("ISA", "GS", "GE", "IEA")
+    expected_segments = []
+
+    for x in x12_with_custom_delimiters.split("\n"):
+        if x.split("|")[0] in control_segments:
+            continue
+        expected_segments.append(x)
+
+    expected_transaction = "\n".join(expected_segments)
+
+    with X12ModelReader(x12_with_custom_delimiters) as r:
+        model_result = [m for m in r.models()]
+        assert len(model_result) == 1
+        assert model_result[0].x12() == expected_transaction

--- a/x12/parsing.py
+++ b/x12/parsing.py
@@ -208,7 +208,7 @@ class X12Parser(ABC):
         :return: The parsed data as a dictionary.
         """
 
-        segment_data: Dict = {}
+        segment_data: Dict = {"delimiters": self._delimiters.dict()}
         field_names: List = self._get_segment_field_names(segment_name)
         multivalue_fields: Dict = self._get_multivalue_fields(segment_name)
 


### PR DESCRIPTION
This PR resolves #33 by updating the X12ModelReader to include parsed transaction delimiters with each segment. Please refer to the linked issue for an overview.

Updates include:

* new test cases for X12ModelReader and Segment for "custom" delimiters
* a new pytest fixture to use in test cases
* update to the X12ModelReader to address the issue