### PR TITLE
EligibilityInquiry Property Accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,37 @@ from x12.io import X12ModelReader
 
 with X12ModelReader("/home/edi/270.x12") as r:
     for model in r.models():
-        # common model properties include "header" and "footer"
+        # common model attributes include "header" and "footer"
         print(model.header)
         print(model.footer)
         
         # to convert back to X12
         model.x12()
+```
+
+Each X12 Transaction Model includes property accessors as a convenience. Supported properties vary per transaction.
+```python
+from x12.io import X12ModelReader
+
+def test_property_usage(x12_270_subscriber_input):
+    """A test case used to exercise property usage"""
+
+    with X12ModelReader(x12_270_subscriber_input) as r:
+        transaction_model = [m for m in r.models()][0]
+
+        # the property isn't cached so fetch the subscriber into a variable
+        subscriber = transaction_model.subscriber
+        subscriber_name = subscriber["loop_2100c"]["nm1_segment"]
+        assert subscriber_name["name_last_or_organization_name"] == "DOE"
+        assert subscriber_name["name_first"] == "JOHN"
+        assert subscriber_name["identification_code"] == "00000000001"
+
+        subscriber_transaction = subscriber["trn_segment"][0]
+        assert subscriber_transaction["originating_company_identifier"] == "9800000004"
+
+        info_source_name = transaction_model.information_source["loop_2100a"]["nm1_segment"]
+        assert info_source_name["name_last_or_organization_name"] == "PAYER C"
+        assert info_source_name["identification_code"] == "12345"
 ```
 
 ### CLI

--- a/tests/test_270_005010X279A1.py
+++ b/tests/test_270_005010X279A1.py
@@ -17,3 +17,94 @@ def test_270_dependent(x12_270_dependent_input, x12_270_dependent_transaction):
         model_result = [m for m in r.models()]
         assert len(model_result) == 1
         assert model_result[0].x12() == x12_270_dependent_transaction
+
+
+def test_270_properties_subscriber_use_case(x12_270_subscriber_input):
+    """
+    Tests the Eligibility Inquiry property accessors with the subscriber use-case.
+    The subscriber use-case does not include a dependent record.
+    The input data fixture reflects conventional Eligibility usage where a transaction contains a single
+    information receiver, information source, subscriber, and optionally dependent.
+    """
+
+    with X12ModelReader(x12_270_subscriber_input) as r:
+        transaction_model = [m for m in r.models()][0]
+
+        information_source = transaction_model.information_source
+        assert isinstance(information_source, dict)
+        assert len(information_source) == 2
+        assert "hl_segment" in information_source
+        assert "loop_2100a" in information_source
+
+        information_receiver = transaction_model.information_receiver
+        assert isinstance(information_receiver, dict)
+        assert len(information_receiver) == 2
+        assert "hl_segment" in information_receiver
+        assert "loop_2100b" in information_receiver
+
+        subscriber = transaction_model.subscriber
+        assert isinstance(subscriber, dict)
+        assert len(subscriber) == 3
+        assert "hl_segment" in subscriber
+        assert "trn_segment" in subscriber
+        assert "loop_2100c" in subscriber
+
+        dependent = transaction_model.dependent
+        assert dependent is None
+
+
+def test_270_properties_dependent_use_case(x12_270_dependent_input):
+    """
+    Tests the Eligibility Inquiry property accessors with the dependent use-case.
+    The dependent use-case exercises all available properties.
+    The input data fixture reflects conventional Eligibility usage where a transaction contains a single
+    information receiver, information source, subscriber, and optionally dependent.
+    """
+
+    with X12ModelReader(x12_270_dependent_input) as r:
+        transaction_model = [m for m in r.models()][0]
+
+        information_source = transaction_model.information_source
+        assert len(information_source) == 2
+        assert "hl_segment" in information_source
+        assert "loop_2100a" in information_source
+
+        information_receiver = transaction_model.information_receiver
+        assert len(information_receiver) == 2
+        assert "hl_segment" in information_receiver
+        assert "loop_2100b" in information_receiver
+
+        subscriber = transaction_model.subscriber
+        assert len(subscriber) == 3
+        assert "hl_segment" in subscriber
+        assert "trn_segment" in subscriber
+        assert "loop_2100c" in subscriber
+
+        dependent = transaction_model.dependent
+        assert len(dependent) == 3
+        assert "hl_segment" in dependent
+        assert "trn_segment" in dependent
+        assert "loop_2100d" in dependent
+
+
+def test_property_usage(x12_270_subscriber_input):
+    """A test case used to exercise property usage"""
+
+    with X12ModelReader(x12_270_subscriber_input) as r:
+        transaction_model = [m for m in r.models()][0]
+
+        # the property isn't cached so fetch the subscriber into a variable
+        subscriber = transaction_model.subscriber
+        subscriber_name = subscriber["loop_2100c"]["nm1_segment"]
+        assert subscriber_name["name_last_or_organization_name"] == "DOE"
+        assert subscriber_name["name_first"] == "JOHN"
+        assert subscriber_name["identification_code"] == "00000000001"
+
+        subscriber_transaction = subscriber["trn_segment"][0]
+        assert subscriber_transaction["originating_company_identifier"] == "9800000004"
+
+        info_source_name = transaction_model.information_source["loop_2100a"][
+            "nm1_segment"
+        ]
+        assert info_source_name["name_last_or_organization_name"] == "PAYER C"
+        assert info_source_name["identification_code"] == "12345"

--- a/x12/transactions/x12_270_005010X279A1/transaction_set.py
+++ b/x12/transactions/x12_270_005010X279A1/transaction_set.py
@@ -4,7 +4,7 @@ transaction_set.py
 Defines the Eligibility 270 005010X279A1 transaction set model.
 """
 
-from typing import List
+from typing import List, Dict, Union
 
 from x12.models import X12SegmentGroup
 
@@ -17,3 +17,69 @@ class EligibilityInquiry(X12SegmentGroup):
     header: Header
     loop_2000a: List[Loop2000A]
     footer: Footer
+
+    @property
+    def information_source(self, return_first=True) -> Union[List, Dict]:
+        """
+        Returns Information Source Loops 2000A and 2100A within a single "record" (dictionary).
+
+        :param return_first: Indicates if the first result is returned. When set to False all results are returned.
+        :returns: Dictionary if return_first = True, otherwise returns a List
+        """
+        result = [
+            info_source.dict(exclude={"loop_2000b"}) for info_source in self.loop_2000a
+        ]
+        return result[0] if return_first else result
+
+    @property
+    def information_receiver(self, return_first=True) -> Union[List, Dict]:
+        """
+        Returns Information Receiver Loops 2000B and 2100B within a single "record" (dictionary).
+
+        :param return_first: Indicates if the first result is returned. When set to False all results are returned.
+        :returns: Dictionary if return_first = True, otherwise returns a List
+        """
+        result = []
+
+        for info_source in self.loop_2000a:
+            for info_receiver in info_source.loop_2000b:
+                result.append(info_receiver.dict(exclude={"loop_2000c"}))
+        return result[0] if return_first else result
+
+    @property
+    def subscriber(self, return_first=True) -> Union[List, Dict]:
+        """
+        Returns Subscriber Loops 2000C, 2100C, and 2110C within a single "record" (dictionary).
+
+        :param return_first: Indicates if the first result is returned. When set to False all results are returned.
+        :returns: Dictionary if return_first = True, otherwise returns a List
+        """
+        result = []
+
+        for info_source in self.loop_2000a:
+            for info_receiver in info_source.loop_2000b:
+                for subscriber in info_receiver.loop_2000c:
+                    result.append(subscriber.dict(exclude={"loop_2000d"}))
+        return result[0] if return_first else result
+
+    @property
+    def dependent(self, return_first=True) -> Union[List, Dict]:
+        """
+        Returns Dependent Loops 2000D, 2100D, and 2110D within a single "record" (dictionary).
+
+        :param return_first: Indicates if the first result is returned. When set to False all results are returned.
+        :returns: Dictionary or List if a dependent is present, based on `return_first`. If no dependent is present, returns None.
+        """
+        result = []
+
+        for info_source in self.loop_2000a:
+            for info_receiver in info_source.loop_2000b:
+                for subscriber in info_receiver.loop_2000c:
+                    if subscriber.loop_2000d:
+                        for dependent in subscriber.loop_2000d:
+                            result.append(dependent.dict())
+
+        if return_first:
+            return result[0] if result else None
+        else:
+            return result if len(result) else None


### PR DESCRIPTION
This PR adds property accessors to the EligibilityInquiry transaction model to provide convenient access to:

* Information Source
* Information Receiver
* Subscriber
* Dependent

The property accessors are implemented to "fetch on demand" , meaning that the data is not cached. I opted not to include caching for this initial implementation since we would need to reconcile whether or not our transaction models will be immutable. Once we have that discussion, I think we can move forward with an appropriate strategy.

Additionally, we will revisit this issue after #35 is resolved so that we can exclude the x12 delimiters from the model export.

Finally the 270/271 ASC X12 specification supports an arbitrarily nested data structure. I haven't included test cases for this data structure but rather focused on real world usage where a 270 transaction includes a single source, receiver, subscriber, and optionally dependent.

resolves #27 