### PR TITLE
Removing literal .env path resolution

### DIFF
--- a/src/x12/__init__.py
+++ b/src/x12/__init__.py
@@ -1,1 +1,10 @@
-__version__ = "0.11.0"
+"""
+x12 package
+
+Root package for LinuxForHealth X12 library.
+"""
+from dotenv import load_dotenv
+
+load_dotenv()
+
+__version__ = "0.11.1"

--- a/src/x12/config.py
+++ b/src/x12/config.py
@@ -3,11 +3,8 @@ config.py
 
 LinuxForHealth X12 Configuration Settings and specification/format "constants"
 """
-import os
 from enum import IntEnum
 from functools import lru_cache
-from os.path import abspath, dirname
-
 from pydantic import BaseSettings, Field
 
 
@@ -54,7 +51,6 @@ class X12Config(BaseSettings):
 
     class Config:
         case_sensitive = False
-        env_file = os.path.join(dirname(dirname(dirname(abspath(__file__)))), ".env")
 
 
 @lru_cache


### PR DESCRIPTION
This PR updates addresses and issue where environment variable/settings are not applied to the X12 project when it is referenced as a library. The issue was caused by manually resolving the path to the .env rather than using dot env's "load_dotenv" function. This update loads the env settings correctly (it walks up the directory structure until it finds the file) and allows settings to be overriden by environment variables.

Note: The .env file is not included in builds to ensure that it's not applied to "deployments"

fixes #47 