### PR TITLE
Updated Parser Context to Support a Loop Path

### DIFF
--- a/src/tests/test_parsing_matcher.py
+++ b/src/tests/test_parsing_matcher.py
@@ -17,7 +17,7 @@ def segment_data(x12_delimiters) -> Dict:
 @pytest.fixture
 def parser_function() -> Callable:
     def func(x12_parser_context: X12ParserContext):
-        x12_parser_context.loop_name = "test_loop"
+        x12_parser_context.loop_path.append("test_loop")
 
     return func
 

--- a/src/x12/parsing.py
+++ b/src/x12/parsing.py
@@ -82,6 +82,16 @@ class X12ParserContext:
     The X12ParserContext provides a "current" loop data record used to write to the outer transaction data record.
     """
 
+    @property
+    def loop_name(self):
+        """return the current loop name"""
+        return None if not self.loop_path else self.loop_path[-1]
+
+    def remove_loop_from_path(self, loop_name: str) -> None:
+        """Removes a loop from the loop path"""
+        if loop_name in self.loop_path:
+            self.loop_path.remove(loop_name)
+
     def set_loop_context(self, loop_name: str, loop_container: Dict) -> None:
         """
         Sets the current loop context.
@@ -93,13 +103,13 @@ class X12ParserContext:
         :param loop_container: The "current" loop record.
         """
 
-        self.loop_name = loop_name
+        self.loop_path.append(loop_name)
         self.loop_container = loop_container
 
     def reset_loop_context(self) -> None:
         """Resets loop related instance attributes."""
 
-        self.loop_name = None
+        self.loop_path.clear()
         self.loop_container = {}
 
     def reset_transaction(self) -> None:
@@ -123,7 +133,7 @@ class X12ParserContext:
         models.
         """
 
-        self.loop_name: Optional[str] = None
+        self.loop_path: List[str] = []
         self.loop_container: Optional[Dict] = {}
         self.transaction_data: Optional[Dict] = {"header": {}, "footer": {}}
         self.is_transaction_complete: bool = False

--- a/src/x12/transactions/x12_270_005010X279A1/parsing.py
+++ b/src/x12/transactions/x12_270_005010X279A1/parsing.py
@@ -74,6 +74,8 @@ def set_information_source_hl_loop(context: X12ParserContext) -> None:
     :param context: The X12Parsing context which contains the current loop and transaction record.
     """
 
+    context.reset_loop_context()
+
     if TransactionLoops.INFORMATION_SOURCE not in context.transaction_data:
         context.transaction_data[TransactionLoops.INFORMATION_SOURCE] = [{}]
     else:
@@ -99,6 +101,8 @@ def set_information_receiver_hl_loop(context: X12ParserContext) -> None:
         info_source[TransactionLoops.INFORMATION_RECEIVER].append({})
 
     info_receiver = info_source[TransactionLoops.INFORMATION_RECEIVER][-1]
+
+    context.remove_loop_from_path(TransactionLoops.INFORMATION_SOURCE_NAME)
     context.set_loop_context(TransactionLoops.INFORMATION_RECEIVER, info_receiver)
 
 
@@ -121,6 +125,7 @@ def set_subscriber_hl_loop(context: X12ParserContext) -> None:
     subscriber = info_receiver[TransactionLoops.SUBSCRIBER][-1]
     subscriber["trn_segment"] = []
 
+    context.remove_loop_from_path(TransactionLoops.INFORMATION_RECEIVER_NAME)
     context.set_loop_context(TransactionLoops.SUBSCRIBER, subscriber)
 
 
@@ -177,6 +182,7 @@ def set_dependent_hl_loop(context: X12ParserContext) -> None:
     dependent = subscriber[TransactionLoops.DEPENDENT][-1]
     dependent["trn_segment"] = []
 
+    context.remove_loop_from_path(TransactionLoops.SUBSCRIBER_NAME)
     context.set_loop_context(TransactionLoops.DEPENDENT, dependent)
 
 
@@ -188,6 +194,7 @@ def set_se_loop(context: X12ParserContext) -> None:
     :param context: The X12Parsing context which contains the current loop and transaction record.
     """
 
+    context.reset_loop_context()
     context.set_loop_context(
         TransactionLoops.FOOTER, context.transaction_data["footer"]
     )

--- a/src/x12/transactions/x12_271_005010X279A1/parsing.py
+++ b/src/x12/transactions/x12_271_005010X279A1/parsing.py
@@ -124,6 +124,8 @@ def set_info_source_loop(context: X12ParserContext) -> None:
         "loop_2000b": [],
     }
 
+    context.reset_loop_context()
+
     if TransactionLoops.INFORMATION_SOURCE not in context.transaction_data:
         context.transaction_data[TransactionLoops.INFORMATION_SOURCE] = []
 
@@ -163,6 +165,7 @@ def set_info_receiver_loop(context: X12ParserContext) -> None:
     )
 
     info_receiver = info_source[TransactionLoops.INFORMATION_RECEIVER][-1]
+    context.remove_loop_from_path(TransactionLoops.INFORMATION_SOURCE_NAME)
     context.set_loop_context(TransactionLoops.INFORMATION_RECEIVER, info_receiver)
 
 
@@ -206,6 +209,7 @@ def set_subscriber_loop(context: X12ParserContext) -> None:
     )
 
     subscriber = info_receiver[TransactionLoops.SUBSCRIBER][-1]
+    context.remove_loop_from_path(TransactionLoops.INFORMATION_RECEIVER_NAME)
     context.set_loop_context(TransactionLoops.SUBSCRIBER, subscriber)
 
 
@@ -227,6 +231,7 @@ def set_dependent_loop(context: X12ParserContext) -> None:
     )
 
     dependent = subscriber[TransactionLoops.DEPENDENT][-1]
+    context.remove_loop_from_path(TransactionLoops.SUBSCRIBER_NAME)
     context.set_loop_context(TransactionLoops.DEPENDENT, dependent)
 
 
@@ -367,6 +372,7 @@ def set_loop_header_in_eligibility_loop(context: X12ParserContext) -> None:
         }
     )
 
+    context.remove_loop_from_path(TransactionLoops.SUBSCRIBER_ADDITIONAL_ELIGIBILITY)
     context.set_loop_context(loop_name, eligibility_record)
 
 
@@ -394,6 +400,7 @@ def set_benefit_related_entity_name_loop(context: X12ParserContext) -> None:
         loop_name = TransactionLoops.DEPENDENT_RELATED_BENEFIT_NAME
 
     related_entity = eligibility[loop_name][-1]
+    context.remove_loop_from_path(TransactionLoops.SUBSCRIBER_RELATED_BENEFIT_NAME)
     context.set_loop_context(loop_name, related_entity)
 
 
@@ -420,6 +427,7 @@ def set_se_loop(context: X12ParserContext) -> None:
     :param context: The X12Parsing context which contains the current loop and transaction record.
     """
 
+    context.reset_loop_context()
     context.set_loop_context(
         TransactionLoops.FOOTER, context.transaction_data["footer"]
     )


### PR DESCRIPTION
This PR updates the X12 Parser Context to support the notion of a "loop path". The "loop path" is an ordered list or sequence of loop names which provide insight into the loop hierarchy for the current segment. This is an update that's required for appropriate position of the claim related loops and segments in the forthcoming 837 parsing support.

Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>
