### PR TITLE
Update Match Conditions to Support Lists

### DIFF
--- a/src/tests/test_parsing_matcher.py
+++ b/src/tests/test_parsing_matcher.py
@@ -31,13 +31,28 @@ def test_match_no_conditions(parser_function, segment_data, x12_parser_context):
     assert x12_parser_context.loop_name == "test_loop"
 
 
-def test_match_conditions(parser_function, segment_data, x12_parser_context):
+def test_single_match_condition(parser_function, segment_data, x12_parser_context):
     """
     Tests the match decorator when conditions are specified.
     """
     wrapped_func = match("ST", conditions={"transaction_set_identifier_code": "270"})(
         parser_function
     )
+    wrapped_func(segment_data, x12_parser_context)
+    assert x12_parser_context.loop_name == "test_loop"
+
+
+def test_multiple_match_condition(parser_function, segment_data, x12_parser_context):
+    """
+    Tests the match decorator when conditions are specified.
+    """
+    wrapped_func = match(
+        "ST",
+        conditions={
+            "transaction_set_identifier_code": "270",
+            "transaction_set_control_number": "0001",
+        },
+    )(parser_function)
     wrapped_func(segment_data, x12_parser_context)
     assert x12_parser_context.loop_name == "test_loop"
 

--- a/src/tests/test_parsing_matcher.py
+++ b/src/tests/test_parsing_matcher.py
@@ -61,9 +61,9 @@ def test_list_match_condition(parser_function, segment_data, x12_parser_context)
     """
     Tests the match decorator when conditions are specified.
     """
-    wrapped_func = match("ST", conditions={"transaction_set_identifier_code": ["270", "276"]})(
-        parser_function
-    )
+    wrapped_func = match(
+        "ST", conditions={"transaction_set_identifier_code": ["270", "276"]}
+    )(parser_function)
     wrapped_func(segment_data, x12_parser_context)
     assert x12_parser_context.loop_name == "test_loop"
 

--- a/src/tests/test_parsing_matcher.py
+++ b/src/tests/test_parsing_matcher.py
@@ -57,6 +57,17 @@ def test_multiple_match_condition(parser_function, segment_data, x12_parser_cont
     assert x12_parser_context.loop_name == "test_loop"
 
 
+def test_list_match_condition(parser_function, segment_data, x12_parser_context):
+    """
+    Tests the match decorator when conditions are specified.
+    """
+    wrapped_func = match("ST", conditions={"transaction_set_identifier_code": ["270", "276"]})(
+        parser_function
+    )
+    wrapped_func(segment_data, x12_parser_context)
+    assert x12_parser_context.loop_name == "test_loop"
+
+
 def test_match_conditions_unmatched(parser_function, segment_data, x12_parser_context):
     """
     Tests the match decorator when conditions are specified but they do not match the data_segment.

--- a/src/x12/parsing.py
+++ b/src/x12/parsing.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 PARSING_FUNCTION_REGEX = "set\\_(.)*\\_loop"
 
 
-def match(segment_name: str, conditions: Dict[str, str] = None) -> Callable:
+def match(segment_name: str, conditions: Dict = None) -> Callable:
     """
     The match decorator matches a X12 segment to a decorated function.
 


### PR DESCRIPTION
This PR updates the match condition decorator to support lists for "one of" checks.