### PR TITLE
Migrate loop_path to parsed_loops

### DIFF
--- a/src/tests/test_parsing_matcher.py
+++ b/src/tests/test_parsing_matcher.py
@@ -17,7 +17,7 @@ def segment_data(x12_delimiters) -> Dict:
 @pytest.fixture
 def parser_function() -> Callable:
     def func(x12_parser_context: X12ParserContext):
-        x12_parser_context.loop_path.append("test_loop")
+        x12_parser_context.parsed_loops.append("test_loop")
 
     return func
 

--- a/src/tests/test_x12_parser_context.py
+++ b/src/tests/test_x12_parser_context.py
@@ -25,16 +25,6 @@ def test_set_loop_context(x12_parser_context: X12ParserContext):
     assert x12_parser_context.loop_container == {}
 
 
-def test_reset_loop_context(x12_parser_context: X12ParserContext):
-
-    x12_parser_context.set_loop_context(
-        "header", x12_parser_context.transaction_data["header"]
-    )
-    x12_parser_context.reset_loop_context()
-    assert x12_parser_context.loop_name is None
-    assert x12_parser_context.loop_container == {}
-
-
 def test_reset_transaction(x12_parser_context: X12ParserContext):
     x12_parser_context.reset_transaction()
     assert x12_parser_context.transaction_data == {"header": {}, "footer": {}}

--- a/src/x12/parsing.py
+++ b/src/x12/parsing.py
@@ -89,43 +89,37 @@ def match(segment_name: str, conditions: Dict = None) -> Callable:
 
 class X12ParserContext:
     """
-    The X12ParserContext provides a "current" loop data record used to write to the outer transaction data record.
+    The X12ParserContext maintains the current loop position within the larger x12 transactional data structure.
     """
 
     @property
     def loop_name(self):
         """return the current loop name"""
-        return None if not self.loop_path else self.loop_path[-1]
-
-    def remove_loop_from_path(self, loop_name: str) -> None:
-        """Removes a loop from the loop path"""
-        if loop_name in self.loop_path:
-            self.loop_path.remove(loop_name)
+        return None if not self.parsed_loops else self.parsed_loops[-1]
 
     def set_loop_context(self, loop_name: str, loop_container: Dict) -> None:
         """
         Sets the current loop context.
 
-        The loop context includes the loop name and the loop "container". The "loop container" is expected to
+        The loop context includes a list of parsed loops and the loop "container". The "loop container" is expected to
         reference the larger transactional data structure.
 
         :param loop_name: The "current" loop name.
         :param loop_container: The "current" loop record.
         """
 
-        self.loop_path.append(loop_name)
+        self.parsed_loops.append(loop_name)
         self.loop_container = loop_container
 
     def reset_loop_context(self) -> None:
         """Resets loop related instance attributes."""
 
-        self.loop_path.clear()
         self.loop_container = {}
 
     def reset_transaction(self) -> None:
         """Resets transactional attributes, including loop attributes."""
 
-        self.reset_loop_context()
+        self.parsed_loops.clear()
         self.transaction_data.clear()
         self.transaction_data["header"] = {}
         self.transaction_data["footer"] = {}
@@ -143,7 +137,7 @@ class X12ParserContext:
         models.
         """
 
-        self.loop_path: List[str] = []
+        self.parsed_loops: List[str] = []
         self.loop_container: Optional[Dict] = {}
         self.transaction_data: Optional[Dict] = {"header": {}, "footer": {}}
         self.is_transaction_complete: bool = False

--- a/src/x12/transactions/x12_270_005010X279A1/parsing.py
+++ b/src/x12/transactions/x12_270_005010X279A1/parsing.py
@@ -74,8 +74,6 @@ def set_information_source_hl_loop(context: X12ParserContext) -> None:
     :param context: The X12Parsing context which contains the current loop and transaction record.
     """
 
-    context.reset_loop_context()
-
     if TransactionLoops.INFORMATION_SOURCE not in context.transaction_data:
         context.transaction_data[TransactionLoops.INFORMATION_SOURCE] = [{}]
     else:
@@ -102,7 +100,6 @@ def set_information_receiver_hl_loop(context: X12ParserContext) -> None:
 
     info_receiver = info_source[TransactionLoops.INFORMATION_RECEIVER][-1]
 
-    context.remove_loop_from_path(TransactionLoops.INFORMATION_SOURCE_NAME)
     context.set_loop_context(TransactionLoops.INFORMATION_RECEIVER, info_receiver)
 
 
@@ -125,7 +122,6 @@ def set_subscriber_hl_loop(context: X12ParserContext) -> None:
     subscriber = info_receiver[TransactionLoops.SUBSCRIBER][-1]
     subscriber["trn_segment"] = []
 
-    context.remove_loop_from_path(TransactionLoops.INFORMATION_RECEIVER_NAME)
     context.set_loop_context(TransactionLoops.SUBSCRIBER, subscriber)
 
 
@@ -182,7 +178,6 @@ def set_dependent_hl_loop(context: X12ParserContext) -> None:
     dependent = subscriber[TransactionLoops.DEPENDENT][-1]
     dependent["trn_segment"] = []
 
-    context.remove_loop_from_path(TransactionLoops.SUBSCRIBER_NAME)
     context.set_loop_context(TransactionLoops.DEPENDENT, dependent)
 
 
@@ -194,7 +189,6 @@ def set_se_loop(context: X12ParserContext) -> None:
     :param context: The X12Parsing context which contains the current loop and transaction record.
     """
 
-    context.reset_loop_context()
     context.set_loop_context(
         TransactionLoops.FOOTER, context.transaction_data["footer"]
     )

--- a/src/x12/transactions/x12_271_005010X279A1/parsing.py
+++ b/src/x12/transactions/x12_271_005010X279A1/parsing.py
@@ -124,8 +124,6 @@ def set_info_source_loop(context: X12ParserContext) -> None:
         "loop_2000b": [],
     }
 
-    context.reset_loop_context()
-
     if TransactionLoops.INFORMATION_SOURCE not in context.transaction_data:
         context.transaction_data[TransactionLoops.INFORMATION_SOURCE] = []
 
@@ -165,7 +163,6 @@ def set_info_receiver_loop(context: X12ParserContext) -> None:
     )
 
     info_receiver = info_source[TransactionLoops.INFORMATION_RECEIVER][-1]
-    context.remove_loop_from_path(TransactionLoops.INFORMATION_SOURCE_NAME)
     context.set_loop_context(TransactionLoops.INFORMATION_RECEIVER, info_receiver)
 
 
@@ -209,7 +206,6 @@ def set_subscriber_loop(context: X12ParserContext) -> None:
     )
 
     subscriber = info_receiver[TransactionLoops.SUBSCRIBER][-1]
-    context.remove_loop_from_path(TransactionLoops.INFORMATION_RECEIVER_NAME)
     context.set_loop_context(TransactionLoops.SUBSCRIBER, subscriber)
 
 
@@ -231,7 +227,6 @@ def set_dependent_loop(context: X12ParserContext) -> None:
     )
 
     dependent = subscriber[TransactionLoops.DEPENDENT][-1]
-    context.remove_loop_from_path(TransactionLoops.SUBSCRIBER_NAME)
     context.set_loop_context(TransactionLoops.DEPENDENT, dependent)
 
 
@@ -372,7 +367,6 @@ def set_loop_header_in_eligibility_loop(context: X12ParserContext) -> None:
         }
     )
 
-    context.remove_loop_from_path(TransactionLoops.SUBSCRIBER_ADDITIONAL_ELIGIBILITY)
     context.set_loop_context(loop_name, eligibility_record)
 
 
@@ -400,7 +394,6 @@ def set_benefit_related_entity_name_loop(context: X12ParserContext) -> None:
         loop_name = TransactionLoops.DEPENDENT_RELATED_BENEFIT_NAME
 
     related_entity = eligibility[loop_name][-1]
-    context.remove_loop_from_path(TransactionLoops.SUBSCRIBER_RELATED_BENEFIT_NAME)
     context.set_loop_context(loop_name, related_entity)
 
 
@@ -427,7 +420,6 @@ def set_se_loop(context: X12ParserContext) -> None:
     :param context: The X12Parsing context which contains the current loop and transaction record.
     """
 
-    context.reset_loop_context()
     context.set_loop_context(
         TransactionLoops.FOOTER, context.transaction_data["footer"]
     )


### PR DESCRIPTION
This PR migrates the X12ParserContext.loop_path attribute to "parsed_loops". The parsed_loops attribute is a list which simply tracks all loops which have been received and parsed.