### PR TITLE
Implement Loop Specific PWK Segments for 837p and 837i

### DIFF
--- a/src/x12/segments.py
+++ b/src/x12/segments.py
@@ -2296,92 +2296,9 @@ class PwkSegment(X12Segment):
         PWK*OZ*BM***AC*DMN0012~
     """
 
-    class AttachmentReportTypeCode(str, Enum):
-        """
-        PWK01 code values
-        """
-
-        REPORT_JUSTIFYING_TREATMENT_BEYOND_UTILIZATION_GUIDELINES = "03"
-        DRUGS_ADMINISTERED = "04"
-        TREATMENT_DIAGNOSIS = "05"
-        INITIAL_ASSESSMENT = "06"
-        FUNCTIONAL_GOALS = "07"
-        PLAN_OF_TREATMENT = "08"
-        PROGRESS_REPORT = "09"
-        CONTINUED_TREATMENT = "10"
-        CHEMICAL_ANALYSIS = "11"
-        CERTIFIED_TEST_REPORT = "13"
-        JUSTIFICATION_FOR_ADMISSION = "15"
-        RECOVERY_PLAN = "21"
-        ALLERGIES_SENSITIVITIES_DOCUMENT = "A3"
-        AUTOPSY_REPORT = "A4"
-        AMBULANCE_CERTIFICATION = "AM"
-        ADMISSION_SUMMARY = "AS"
-        PRESCRIPTION = "B2"
-        PHYSICIAN_ORDER = "B3"
-        REFERRAL_FORM = "B4"
-        BENCHMARK_TESTING_RESULTS = "BR"
-        BASELINE = "BS"
-        BLANKET_TESTING_RESULTS = "BT"
-        CHIROPRACTIC_JUSTIFICATION = "CB"
-        CONSENT_FORM = "CK"
-        CERTIFICATION = "CT"
-        DRUG_PROFILE_DOCUMENT = "D2"
-        DENTAL_MODELS = "DA"
-        DURABLE_MEDICAL_EQUIPMENT_PRESCRIPTION = "DB"
-        DIAGNOSTIC_REPORT = "DG"
-        DISCHARGE_MONITORING_REPORT = "DJ"
-        DISCHARGE_SUMMARY = "DS"
-        EXPLANATION_OF_BENEFITS = "EB"
-        HEALTH_CERTIFICATE = "HC"
-        HEALTH_CLINIC_RECORDS = "HR"
-        IMMUNIZATION_RECORD = "I5"
-        STATE_SCHOOL_IMMUNIZATION_RECORDS = "IR"
-        LABORATORY_RESULTS = "LA"
-        MEDICAL_RECORD_ATTACHMENT = "M1"
-        MODELS = "MT"
-        NURSING_NOTES = "NN"
-        OPERATIVE_NOTE = "OB"
-        OXYGEN_CONTENT_AVERAGING_REPORT = "OC"
-        ORDERS_AND_TREATMENTS_DOCUMENT = "OD"
-        OBJECTIVE_PHYSICAL_EXAMINATION = "OE"
-        OXYGEN_THERAPY_CERTIFICATION = "OX"
-        SUPPORT_DATA_FOR_CLAIM = "OZ"
-        PATHOLOGY_REPORT = "P4"
-        PATIENT_MEDICAL_HISTORY_DOCUMENT = "P5"
-        PARENTAL_OR_ENTERAL_CERTIFICATION = "PE"
-        PHYSICAL_THERAPY_NOTES = "PN"
-        PROSTHETICS_OR_ORTHOTIC_CERTIFICATION = "PO"
-        PARAMEDICAL_RESULTS = "PQ"
-        PHYSICIANS_REPORT = "PY"
-        PHYSICAL_THERAPY_CERTIFICATION = "PZ"
-        RADIOLOGY_FILMS = "RB"
-        RADIOLOGY_REPORTS = "RR"
-        REPORT_OF_TESTS_AND_ANALYSIS_REPORT = "RT"
-        RENEWABLE_OXYGEN_CONTENT_AVERAGING_REPORT = "RX"
-        SYMPTOMS_DOCUMENT = "SG"
-        DEATH_NOTIFICATION = "V5"
-        PHOTOGRAPHS = "XP"
-
-    class AttachmentTransmissionCode(str, Enum):
-        """
-        Code values for PWK02
-        """
-
-        AVAILABLE_ON_REQUEST_PROVIDER_SITE = "AA"
-        PREVIOUSLY_SUBMITTED_TO_PAYER = "AB"
-        CERTIFICATION_INCLUDED_IN_THIS_CLAIM = "AD"
-        NARRATIVE_SUPPORT_INCLUDED_IN_THIS_CLAIM = "AF"
-        NOT_SPECIFIED = "NS"
-        BY_MAIL = "BM"
-        ELECTRONICALLY_ONLY = "EL"
-        EMAIL = "EM"
-        FILE_TRANSFER = "FT"
-        BY_FAX = "FX"
-
     segment_name: X12SegmentName = X12SegmentName.PWK
-    report_type_code: AttachmentReportTypeCode
-    report_transmission_code: AttachmentTransmissionCode
+    report_type_code: str = Field(min_length=2, max_length=2)
+    report_transmission_code: str = Field(min_length=1, max_length=2)
     report_copies_needed: Optional[str] = Field(max_length=2)
     entity_identifier_code: Optional[str] = Field(max_length=3)
     identification_code_qualifier: Optional[str] = Field(max_length=2)

--- a/src/x12/transactions/x12_837_005010X222A2/loops.py
+++ b/src/x12/transactions/x12_837_005010X222A2/loops.py
@@ -70,6 +70,7 @@ from .segments import (
     Loop2010BbNm1Segment,
     Loop2010BbRefSegment,
     Loop2300DtpSegment,
+    Loop2300PwkSegment,
     Loop2300Cn1Segment,
     Loop2300AmtSegment,
     Loop2300RefSegment,
@@ -108,6 +109,7 @@ from .segments import (
     Loop2330fRefSegment,
     Loop2330gNm1Segment,
     Loop2330gRefSegment,
+    Loop2400PwkSegment,
     Loop2400CrcSegment,
     Loop2400DtpSegment,
     Loop2400QtySegment,
@@ -156,7 +158,6 @@ from x12.segments import (
     LxSegment,
     Sv1Segment,
     Sv5Segment,
-    PwkSegment,
     Cr3Segment,
     MeaSegment,
     Ps1Segment,
@@ -518,7 +519,7 @@ class Loop2400(X12SegmentGroup):
     lx_segment: LxSegment
     sv1_segment: Sv1Segment
     sv5_segment: Optional[Sv5Segment]
-    pwk_segment: Optional[List[PwkSegment]] = Field(min_items=0, max_items=10)
+    pwk_segment: Optional[List[Loop2400PwkSegment]] = Field(min_items=0, max_items=10)
     cr1_segment: Optional[Cr1Segment]
     cr3_segment: Optional[Cr3Segment]
     crc_segment: Optional[List[Loop2400CrcSegment]] = Field(min_items=0, max_items=5)
@@ -556,7 +557,7 @@ class Loop2300(X12SegmentGroup):
 
     clm_segment: ClmSegment
     dtp_segment: Optional[List[Loop2300DtpSegment]] = Field(min_items=0, max_items=17)
-    pwk_segment: Optional[List[PwkSegment]] = Field(min_items=0, max_items=10)
+    pwk_segment: Optional[List[Loop2300PwkSegment]] = Field(min_items=0, max_items=10)
     cn1_segment: Optional[Loop2300Cn1Segment]
     amt_segment: Optional[Loop2300AmtSegment]
     ref_segment: Optional[List[Loop2300RefSegment]] = Field(min_items=0, max_items=14)

--- a/src/x12/transactions/x12_837_005010X222A2/segments.py
+++ b/src/x12/transactions/x12_837_005010X222A2/segments.py
@@ -19,9 +19,8 @@ from x12.segments import (
     NteSegment,
     CrcSegment,
     PatSegment,
-    HcpSegment,
     QtySegment,
-    CasSegment,
+    PwkSegment,
 )
 from typing import Literal, Optional, Dict
 from enum import Enum
@@ -500,6 +499,91 @@ class Loop2300DtpSegment(DtpSegment):
                 "RD8 Date Time Period is required for Disability Dates (314)"
             )
         return values
+
+
+class Loop2300PwkSegment(PwkSegment):
+    """
+    Claim information paperwork segment
+    """
+
+    class AttachmentReportTypeCode(str, Enum):
+        """
+        PWK01 code values
+        """
+
+        REPORT_JUSTIFYING_TREATMENT_BEYOND_UTILIZATION_GUIDELINES = "03"
+        DRUGS_ADMINISTERED = "04"
+        TREATMENT_DIAGNOSIS = "05"
+        INITIAL_ASSESSMENT = "06"
+        FUNCTIONAL_GOALS = "07"
+        PLAN_OF_TREATMENT = "08"
+        PROGRESS_REPORT = "09"
+        CONTINUED_TREATMENT = "10"
+        CHEMICAL_ANALYSIS = "11"
+        CERTIFIED_TEST_REPORT = "13"
+        JUSTIFICATION_FOR_ADMISSION = "15"
+        RECOVERY_PLAN = "21"
+        ALLERGIES_SENSITIVITIES_DOCUMENT = "A3"
+        AUTOPSY_REPORT = "A4"
+        AMBULANCE_CERTIFICATION = "AM"
+        ADMISSION_SUMMARY = "AS"
+        PRESCRIPTION = "B2"
+        PHYSICIAN_ORDER = "B3"
+        REFERRAL_FORM = "B4"
+        BENCHMARK_TESTING_RESULTS = "BR"
+        BASELINE = "BS"
+        BLANKET_TESTING_RESULTS = "BT"
+        CHIROPRACTIC_JUSTIFICATION = "CB"
+        CONSENT_FORM = "CK"
+        CERTIFICATION = "CT"
+        DRUG_PROFILE_DOCUMENT = "D2"
+        DENTAL_MODELS = "DA"
+        DURABLE_MEDICAL_EQUIPMENT_PRESCRIPTION = "DB"
+        DIAGNOSTIC_REPORT = "DG"
+        DISCHARGE_MONITORING_REPORT = "DJ"
+        DISCHARGE_SUMMARY = "DS"
+        EXPLANATION_OF_BENEFITS = "EB"
+        HEALTH_CERTIFICATE = "HC"
+        HEALTH_CLINIC_RECORDS = "HR"
+        IMMUNIZATION_RECORD = "I5"
+        STATE_SCHOOL_IMMUNIZATION_RECORDS = "IR"
+        LABORATORY_RESULTS = "LA"
+        MEDICAL_RECORD_ATTACHMENT = "M1"
+        MODELS = "MT"
+        NURSING_NOTES = "NN"
+        OPERATIVE_NOTE = "OB"
+        OXYGEN_CONTENT_AVERAGING_REPORT = "OC"
+        ORDERS_AND_TREATMENTS_DOCUMENT = "OD"
+        OBJECTIVE_PHYSICAL_EXAMINATION = "OE"
+        OXYGEN_THERAPY_CERTIFICATION = "OX"
+        SUPPORT_DATA_FOR_CLAIM = "OZ"
+        PATHOLOGY_REPORT = "P4"
+        PATIENT_MEDICAL_HISTORY_DOCUMENT = "P5"
+        PARENTAL_OR_ENTERAL_CERTIFICATION = "PE"
+        PHYSICAL_THERAPY_NOTES = "PN"
+        PROSTHETICS_OR_ORTHOTIC_CERTIFICATION = "PO"
+        PARAMEDICAL_RESULTS = "PQ"
+        PHYSICIANS_REPORT = "PY"
+        PHYSICAL_THERAPY_CERTIFICATION = "PZ"
+        RADIOLOGY_FILMS = "RB"
+        RADIOLOGY_REPORTS = "RR"
+        REPORT_OF_TESTS_AND_ANALYSIS_REPORT = "RT"
+        RENEWABLE_OXYGEN_CONTENT_AVERAGING_REPORT = "RX"
+        SYMPTOMS_DOCUMENT = "SG"
+        DEATH_NOTIFICATION = "V5"
+        PHOTOGRAPHS = "XP"
+
+    class AttachmentTransmissionCode(str, Enum):
+        """
+        Code values for PWK02
+        """
+
+        AVAILABLE_ON_REQUEST_PROVIDER_SITE = "AA"
+        BY_MAIL = "BM"
+        ELECTRONICALLY_ONLY = "EL"
+        EMAIL = "EM"
+        FILE_TRANSFER = "FT"
+        BY_FAX = "FX"
 
 
 class Loop2300Cn1Segment(Cn1Segment):
@@ -1159,6 +1243,91 @@ class Loop2330gRefSegment(RefSegment):
         LOCATION_NUMBER = "LU"
 
     reference_identification_qualifier: ReferenceIdentificationQualifier
+
+
+class Loop2400PwkSegment(PwkSegment):
+    """
+    Service Line information paperwork segment
+    """
+
+    class AttachmentReportTypeCode(str, Enum):
+        """
+        PWK01 code values
+        """
+
+        REPORT_JUSTIFYING_TREATMENT_BEYOND_UTILIZATION_GUIDELINES = "03"
+        DRUGS_ADMINISTERED = "04"
+        TREATMENT_DIAGNOSIS = "05"
+        INITIAL_ASSESSMENT = "06"
+        FUNCTIONAL_GOALS = "07"
+        PLAN_OF_TREATMENT = "08"
+        PROGRESS_REPORT = "09"
+        CONTINUED_TREATMENT = "10"
+        CHEMICAL_ANALYSIS = "11"
+        CERTIFIED_TEST_REPORT = "13"
+        JUSTIFICATION_FOR_ADMISSION = "15"
+        RECOVERY_PLAN = "21"
+        ALLERGIES_SENSITIVITIES_DOCUMENT = "A3"
+        AUTOPSY_REPORT = "A4"
+        AMBULANCE_CERTIFICATION = "AM"
+        ADMISSION_SUMMARY = "AS"
+        PRESCRIPTION = "B2"
+        PHYSICIAN_ORDER = "B3"
+        REFERRAL_FORM = "B4"
+        BENCHMARK_TESTING_RESULTS = "BR"
+        BASELINE = "BS"
+        BLANKET_TESTING_RESULTS = "BT"
+        CHIROPRACTIC_JUSTIFICATION = "CB"
+        CONSENT_FORM = "CK"
+        CERTIFICATION = "CT"
+        DRUG_PROFILE_DOCUMENT = "D2"
+        DENTAL_MODELS = "DA"
+        DURABLE_MEDICAL_EQUIPMENT_PRESCRIPTION = "DB"
+        DIAGNOSTIC_REPORT = "DG"
+        DISCHARGE_MONITORING_REPORT = "DJ"
+        DISCHARGE_SUMMARY = "DS"
+        EXPLANATION_OF_BENEFITS = "EB"
+        HEALTH_CERTIFICATE = "HC"
+        HEALTH_CLINIC_RECORDS = "HR"
+        IMMUNIZATION_RECORD = "I5"
+        STATE_SCHOOL_IMMUNIZATION_RECORDS = "IR"
+        LABORATORY_RESULTS = "LA"
+        MEDICAL_RECORD_ATTACHMENT = "M1"
+        MODELS = "MT"
+        NURSING_NOTES = "NN"
+        OPERATIVE_NOTE = "OB"
+        OXYGEN_CONTENT_AVERAGING_REPORT = "OC"
+        ORDERS_AND_TREATMENTS_DOCUMENT = "OD"
+        OBJECTIVE_PHYSICAL_EXAMINATION = "OE"
+        OXYGEN_THERAPY_CERTIFICATION = "OX"
+        SUPPORT_DATA_FOR_CLAIM = "OZ"
+        PATHOLOGY_REPORT = "P4"
+        PATIENT_MEDICAL_HISTORY_DOCUMENT = "P5"
+        PARENTAL_OR_ENTERAL_CERTIFICATION = "PE"
+        PHYSICAL_THERAPY_NOTES = "PN"
+        PROSTHETICS_OR_ORTHOTIC_CERTIFICATION = "PO"
+        PARAMEDICAL_RESULTS = "PQ"
+        PHYSICIANS_REPORT = "PY"
+        PHYSICAL_THERAPY_CERTIFICATION = "PZ"
+        RADIOLOGY_FILMS = "RB"
+        RADIOLOGY_REPORTS = "RR"
+        REPORT_OF_TESTS_AND_ANALYSIS_REPORT = "RT"
+        RENEWABLE_OXYGEN_CONTENT_AVERAGING_REPORT = "RX"
+        SYMPTOMS_DOCUMENT = "SG"
+        DEATH_NOTIFICATION = "V5"
+        PHOTOGRAPHS = "XP"
+
+    class AttachmentTransmissionCode(str, Enum):
+        """
+        Code values for PWK02
+        """
+
+        AVAILABLE_ON_REQUEST_PROVIDER_SITE = "AA"
+        BY_MAIL = "BM"
+        ELECTRONICALLY_ONLY = "EL"
+        EMAIL = "EM"
+        FILE_TRANSFER = "FT"
+        BY_FAX = "FX"
 
 
 class Loop2400CrcSegment(CrcSegment):

--- a/src/x12/transactions/x12_837_005010X223A3/loops.py
+++ b/src/x12/transactions/x12_837_005010X223A3/loops.py
@@ -78,6 +78,7 @@ from .segments import (
     Loop2000CPatSegment,
     Loop2010CaNm1Segment,
     Loop2010CaRefSegment,
+    Loop2300PwkSegment,
     Loop2310ANm1Segment,
     Loop2310ARefSegment,
     Loop2310BNm1Segment,
@@ -113,6 +114,7 @@ from .segments import (
     Loop2330INm1Segment,
     Loop2330IRefSegment,
     Loop2400DtpSegment,
+    Loop2400PwkSegment,
     Loop2400RefSegment,
     Loop2400AmtSegment,
     Loop2400NteSegment,
@@ -146,7 +148,6 @@ from x12.segments import (
     MoaSegment,
     LxSegment,
     Sv2Segment,
-    PwkSegment,
     HcpSegment,
     LinSegment,
     CtpSegment,
@@ -477,7 +478,7 @@ class Loop2400(X12SegmentGroup):
 
     lx_segment: LxSegment
     sv2_segment: Sv2Segment
-    pwk_segment: Optional[List[PwkSegment]] = Field(min_items=0, max_items=10)
+    pwk_segment: Optional[List[Loop2400PwkSegment]] = Field(min_items=0, max_items=10)
     dtp_segment: Optional[Loop2400DtpSegment]
     ref_segment: Optional[List[Loop2400RefSegment]] = Field(min_items=0, max_items=3)
     amt_segment: Optional[List[Loop2400AmtSegment]] = Field(min_items=0, max_items=2)
@@ -499,7 +500,7 @@ class Loop2300(X12SegmentGroup):
     clm_segment: ClmSegment
     dtp_segment: List[Loop2300DtpSegment] = Field(min_items=1, max_items=4)
     cl1_segment: Cl1Segment
-    pwk_segment: Optional[List[PwkSegment]] = Field(min_items=0, max_items=10)
+    pwk_segment: Optional[List[Loop2300PwkSegment]] = Field(min_items=0, max_items=10)
     cn1_segment: Optional[Loop2300Cn1Segment]
     amt_segment: Optional[Loop2300AmtSegment]
     ref_segment: Optional[List[Loop2300RefSegment]] = Field(min_items=0, max_items=16)

--- a/src/x12/transactions/x12_837_005010X223A3/segments.py
+++ b/src/x12/transactions/x12_837_005010X223A3/segments.py
@@ -20,6 +20,7 @@ from x12.segments import (
     CrcSegment,
     PatSegment,
     HcpSegment,
+    PwkSegment,
 )
 from typing import Literal, Optional, Dict, Union
 from enum import Enum
@@ -465,6 +466,91 @@ class Loop2300DtpSegment(DtpSegment):
                 "RD8 Date Time Period is required for Disability Dates (314)"
             )
         return values
+
+
+class Loop2300PwkSegment(PwkSegment):
+    """
+    Claim information paperwork segment
+    """
+
+    class AttachmentReportTypeCode(str, Enum):
+        """
+        PWK01 code values
+        """
+
+        REPORT_JUSTIFYING_TREATMENT_BEYOND_UTILIZATION_GUIDELINES = "03"
+        DRUGS_ADMINISTERED = "04"
+        TREATMENT_DIAGNOSIS = "05"
+        INITIAL_ASSESSMENT = "06"
+        FUNCTIONAL_GOALS = "07"
+        PLAN_OF_TREATMENT = "08"
+        PROGRESS_REPORT = "09"
+        CONTINUED_TREATMENT = "10"
+        CHEMICAL_ANALYSIS = "11"
+        CERTIFIED_TEST_REPORT = "13"
+        JUSTIFICATION_FOR_ADMISSION = "15"
+        RECOVERY_PLAN = "21"
+        ALLERGIES_SENSITIVITIES_DOCUMENT = "A3"
+        AUTOPSY_REPORT = "A4"
+        AMBULANCE_CERTIFICATION = "AM"
+        ADMISSION_SUMMARY = "AS"
+        PRESCRIPTION = "B2"
+        PHYSICIAN_ORDER = "B3"
+        REFERRAL_FORM = "B4"
+        BENCHMARK_TESTING_RESULTS = "BR"
+        BASELINE = "BS"
+        BLANKET_TESTING_RESULTS = "BT"
+        CHIROPRACTIC_JUSTIFICATION = "CB"
+        CONSENT_FORM = "CK"
+        CERTIFICATION = "CT"
+        DRUG_PROFILE_DOCUMENT = "D2"
+        DENTAL_MODELS = "DA"
+        DURABLE_MEDICAL_EQUIPMENT_PRESCRIPTION = "DB"
+        DIAGNOSTIC_REPORT = "DG"
+        DISCHARGE_MONITORING_REPORT = "DJ"
+        DISCHARGE_SUMMARY = "DS"
+        EXPLANATION_OF_BENEFITS = "EB"
+        HEALTH_CERTIFICATE = "HC"
+        HEALTH_CLINIC_RECORDS = "HR"
+        IMMUNIZATION_RECORD = "I5"
+        STATE_SCHOOL_IMMUNIZATION_RECORDS = "IR"
+        LABORATORY_RESULTS = "LA"
+        MEDICAL_RECORD_ATTACHMENT = "M1"
+        MODELS = "MT"
+        NURSING_NOTES = "NN"
+        OPERATIVE_NOTE = "OB"
+        OXYGEN_CONTENT_AVERAGING_REPORT = "OC"
+        ORDERS_AND_TREATMENTS_DOCUMENT = "OD"
+        OBJECTIVE_PHYSICAL_EXAMINATION = "OE"
+        OXYGEN_THERAPY_CERTIFICATION = "OX"
+        SUPPORT_DATA_FOR_CLAIM = "OZ"
+        PATHOLOGY_REPORT = "P4"
+        PATIENT_MEDICAL_HISTORY_DOCUMENT = "P5"
+        PARENTAL_OR_ENTERAL_CERTIFICATION = "PE"
+        PHYSICAL_THERAPY_NOTES = "PN"
+        PROSTHETICS_OR_ORTHOTIC_CERTIFICATION = "PO"
+        PARAMEDICAL_RESULTS = "PQ"
+        PHYSICIANS_REPORT = "PY"
+        PHYSICAL_THERAPY_CERTIFICATION = "PZ"
+        RADIOLOGY_FILMS = "RB"
+        RADIOLOGY_REPORTS = "RR"
+        REPORT_OF_TESTS_AND_ANALYSIS_REPORT = "RT"
+        RENEWABLE_OXYGEN_CONTENT_AVERAGING_REPORT = "RX"
+        SYMPTOMS_DOCUMENT = "SG"
+        DEATH_NOTIFICATION = "V5"
+        PHOTOGRAPHS = "XP"
+
+    class AttachmentTransmissionCode(str, Enum):
+        """
+        Code values for PWK02
+        """
+
+        AVAILABLE_ON_REQUEST_PROVIDER_SITE = "AA"
+        BY_MAIL = "BM"
+        ELECTRONICALLY_ONLY = "EL"
+        EMAIL = "EM"
+        FILE_TRANSFER = "FT"
+        BY_FAX = "FX"
 
 
 class Loop2300Cn1Segment(Cn1Segment):
@@ -1155,6 +1241,91 @@ class Loop2400DtpSegment(DtpSegment):
 
     date_time_qualifier: Literal["472"]
     date_time_period_format_qualifier: Literal["D8"]
+
+
+class Loop2400PwkSegment(PwkSegment):
+    """
+    Service line paperwork segment
+    """
+
+    class AttachmentReportTypeCode(str, Enum):
+        """
+        PWK01 code values
+        """
+
+        REPORT_JUSTIFYING_TREATMENT_BEYOND_UTILIZATION_GUIDELINES = "03"
+        DRUGS_ADMINISTERED = "04"
+        TREATMENT_DIAGNOSIS = "05"
+        INITIAL_ASSESSMENT = "06"
+        FUNCTIONAL_GOALS = "07"
+        PLAN_OF_TREATMENT = "08"
+        PROGRESS_REPORT = "09"
+        CONTINUED_TREATMENT = "10"
+        CHEMICAL_ANALYSIS = "11"
+        CERTIFIED_TEST_REPORT = "13"
+        JUSTIFICATION_FOR_ADMISSION = "15"
+        RECOVERY_PLAN = "21"
+        ALLERGIES_SENSITIVITIES_DOCUMENT = "A3"
+        AUTOPSY_REPORT = "A4"
+        AMBULANCE_CERTIFICATION = "AM"
+        ADMISSION_SUMMARY = "AS"
+        PRESCRIPTION = "B2"
+        PHYSICIAN_ORDER = "B3"
+        REFERRAL_FORM = "B4"
+        BENCHMARK_TESTING_RESULTS = "BR"
+        BASELINE = "BS"
+        BLANKET_TESTING_RESULTS = "BT"
+        CHIROPRACTIC_JUSTIFICATION = "CB"
+        CONSENT_FORM = "CK"
+        CERTIFICATION = "CT"
+        DRUG_PROFILE_DOCUMENT = "D2"
+        DENTAL_MODELS = "DA"
+        DURABLE_MEDICAL_EQUIPMENT_PRESCRIPTION = "DB"
+        DIAGNOSTIC_REPORT = "DG"
+        DISCHARGE_MONITORING_REPORT = "DJ"
+        DISCHARGE_SUMMARY = "DS"
+        EXPLANATION_OF_BENEFITS = "EB"
+        HEALTH_CERTIFICATE = "HC"
+        HEALTH_CLINIC_RECORDS = "HR"
+        IMMUNIZATION_RECORD = "I5"
+        STATE_SCHOOL_IMMUNIZATION_RECORDS = "IR"
+        LABORATORY_RESULTS = "LA"
+        MEDICAL_RECORD_ATTACHMENT = "M1"
+        MODELS = "MT"
+        NURSING_NOTES = "NN"
+        OPERATIVE_NOTE = "OB"
+        OXYGEN_CONTENT_AVERAGING_REPORT = "OC"
+        ORDERS_AND_TREATMENTS_DOCUMENT = "OD"
+        OBJECTIVE_PHYSICAL_EXAMINATION = "OE"
+        OXYGEN_THERAPY_CERTIFICATION = "OX"
+        SUPPORT_DATA_FOR_CLAIM = "OZ"
+        PATHOLOGY_REPORT = "P4"
+        PATIENT_MEDICAL_HISTORY_DOCUMENT = "P5"
+        PARENTAL_OR_ENTERAL_CERTIFICATION = "PE"
+        PHYSICAL_THERAPY_NOTES = "PN"
+        PROSTHETICS_OR_ORTHOTIC_CERTIFICATION = "PO"
+        PARAMEDICAL_RESULTS = "PQ"
+        PHYSICIANS_REPORT = "PY"
+        PHYSICAL_THERAPY_CERTIFICATION = "PZ"
+        RADIOLOGY_FILMS = "RB"
+        RADIOLOGY_REPORTS = "RR"
+        REPORT_OF_TESTS_AND_ANALYSIS_REPORT = "RT"
+        RENEWABLE_OXYGEN_CONTENT_AVERAGING_REPORT = "RX"
+        SYMPTOMS_DOCUMENT = "SG"
+        DEATH_NOTIFICATION = "V5"
+        PHOTOGRAPHS = "XP"
+
+    class AttachmentTransmissionCode(str, Enum):
+        """
+        Code values for PWK02
+        """
+
+        AVAILABLE_ON_REQUEST_PROVIDER_SITE = "AA"
+        BY_MAIL = "BM"
+        ELECTRONICALLY_ONLY = "EL"
+        EMAIL = "EM"
+        FILE_TRANSFER = "FT"
+        BY_FAX = "FX"
 
 
 class Loop2400RefSegment(RefSegment):


### PR DESCRIPTION
The PWK segment in the base segments module includes ALL (a UNION) for report transmission codes. This PR updates the PWK segment in the base module to be "generic" and "pulls down" appropriate code table values for the 837p and 837i.

resolves #86 

Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>