### PR TITLE
Update Pydantic Dependency to 1.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-    pydantic >= 1.8
+    pydantic >= 1.9
     python-dotenv >=  0.19.0
 package_dir=
     =src

--- a/src/linuxforhealth/x12/__init__.py
+++ b/src/linuxforhealth/x12/__init__.py
@@ -7,4 +7,4 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-__version__ = "0.56.00"
+__version__ = "0.56.01"


### PR DESCRIPTION
This PR updates LinuxForHealth X12's python dependency to version 1.9

closes #109 
Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>