### PR TITLE
Support Consolidated Transaction Set Versions

### DIFF
--- a/repo-docs/NEW_TRANSACTION.md
+++ b/repo-docs/NEW_TRANSACTION.md
@@ -6,7 +6,10 @@ the implementation within the `x12_270_005010X279A1` transaction set before addi
 ## Add Transaction Package
 
 Add a new transaction package to the appropriate top level version package such as `x12.v5010`. The new transaction package name must
-adhere to the following convention to support transaction discovery - `x12_[transaction set code]_[implementation version]`.
+adhere to the following convention to support transaction discovery - `x12_[transaction set code]_[implementation version]`. The
+`implementation version` used in the package name should be the LATEST revision listed in the specification guide. For example
+the claim payment specification includes the following versions: 005010X221 and 005010X221A1. In this case the complete package name
+is `x12_835_005010X221A1` which supports implementation versions `005010X221` and `005010X221A1`.
 
 Add the following modules to the new transaction package:
 

--- a/src/linuxforhealth/x12/parsing.py
+++ b/src/linuxforhealth/x12/parsing.py
@@ -13,7 +13,7 @@ from importlib import import_module
 from typing import Callable, Dict, List, Optional, Set
 
 from .models import X12SegmentGroup, X12Segment, X12Delimiters
-from .support import parse_x12_major_version
+from .support import parse_x12_major_version, get_latest_implementation_version
 
 logger = logging.getLogger(__name__)
 
@@ -345,8 +345,12 @@ def _load_loop_parsers(transaction_code: str, implementation_version) -> Dict:
     loop_parsers = defaultdict(list)
 
     major_version = parse_x12_major_version(implementation_version)
+    latest_implementation_version = get_latest_implementation_version(
+        implementation_version
+    )
+
     parsing_module = import_module(
-        f"{BASE_TRANSACTION_PREFIX}{major_version}.x12_{transaction_code}_{implementation_version}.parsing"
+        f"{BASE_TRANSACTION_PREFIX}{major_version}.x12_{transaction_code}_{latest_implementation_version}.parsing"
     )
 
     funcs = [
@@ -368,9 +372,12 @@ def _load_transaction_model(
     """Returns the transaction model for the x12 transaction"""
 
     major_version = parse_x12_major_version(implementation_version)
+    latest_implementation_version = get_latest_implementation_version(
+        implementation_version
+    )
 
     transaction_module = import_module(
-        f"{BASE_TRANSACTION_PREFIX}{major_version}.x12_{transaction_code}_{implementation_version}.transaction_set"
+        f"{BASE_TRANSACTION_PREFIX}{major_version}.x12_{transaction_code}_{latest_implementation_version}.transaction_set"
     )
 
     # return transaction set model

--- a/src/linuxforhealth/x12/support.py
+++ b/src/linuxforhealth/x12/support.py
@@ -12,6 +12,54 @@ from pydantic import validator, BaseModel
 
 from .config import IsaDelimiters
 
+# maps a X12 transaction implementation version to the latest version in the "major" version
+X12_IMPLEMENTATION_VERSIONS = {
+    # benefit enrollment and maintenance
+    "005010X220": "005010X220A1",
+    "005010X220A1": "005010X220A1",
+    # claims status
+    "005010X212": "005010X212",
+    # claim payment
+    "005010X221": "005010X221A1",
+    "005010X221A1": "005010X221A1",
+    # eligibility inquiry
+    "005010X279": "005010X279A1",
+    "005010X279A1": "005010X279A1",
+    # institutional claim
+    "004010X096": "004010X096A1",
+    "004010X096A1": "004010X096A1",
+    "005010X223": "005010X223A3",
+    "005010X223A1": "005010X223A3",
+    "005010X223A2": "005010X223A3",
+    "005010X223A3": "005010X223A3",
+    # professional claim
+    "004010X098": "004010X098A1",
+    "004010X098A1": "004010X098A1",
+    "005010X222": "005010X222A2",
+    "005010X222A1": "005010X222A2",
+    "005010X222A2": "005010X222A2",
+}
+
+
+def get_latest_implementation_version(requested_version: str) -> str:
+    """
+    Returns the latest implementation version for a requested version.
+    For example, the claim payment specification includes the following versions: 005010X221 and 005010X221A1.
+
+    get_latest_implementation_version("005010X221") returns "005010X221A1"
+    get_latest_implementation_version("005010X221A1") returns "005010X221A1"
+
+    :param requested_version: The requested version used for lookup.
+    :returns: The latest implementation version
+    :raises: KeyError if the requested version is not supported
+
+    """
+    if requested_version not in X12_IMPLEMENTATION_VERSIONS:
+        raise KeyError(
+            f"Unable to match {requested_version} to a specification guide. {requested_version} is not supported"
+        )
+    return X12_IMPLEMENTATION_VERSIONS[requested_version]
+
 
 def is_x12_data(input_data: str) -> bool:
     """

--- a/src/tests/test_support.py
+++ b/src/tests/test_support.py
@@ -12,6 +12,7 @@ from linuxforhealth.x12.support import (
     parse_interchange_date,
     count_segments,
     parse_x12_major_version,
+    get_latest_implementation_version,
 )
 from linuxforhealth.x12.io import X12ModelReader
 
@@ -86,3 +87,12 @@ def test_parse_x12_major_version():
     assert parse_x12_major_version("005010X279A1") == "5010"
     assert parse_x12_major_version("00501") == ""
     assert parse_x12_major_version(None) == ""
+
+
+def test_get_final_implementation_version():
+    assert get_latest_implementation_version("005010X222") == "005010X222A2"
+    assert get_latest_implementation_version("005010X222A1") == "005010X222A2"
+    assert get_latest_implementation_version("005010X222A2") == "005010X222A2"
+
+    with pytest.raises(KeyError):
+        get_latest_implementation_version("invalid-version")


### PR DESCRIPTION
This PR updates the X12 transaction set lookup process used to load parser functions and the transaction set data model to support all versions listed within a specification guide. For example, the claim payment specification includes the following versions: 005010X221 and 005010X221A1. Prior to this PR, an error was raised if the parser encountered the 005010X221 version, since the lookup only supported a direct match on 005010X221A1.

The PR updates the lookup processes to utilize an "implementation version" map to map each supported version in a consolidated guide to the latest/current version in that guide.

closes #110 
