### PR TITLE
Customer Testing

### DIFF
--- a/src/linuxforhealth/x12/parsing.py
+++ b/src/linuxforhealth/x12/parsing.py
@@ -25,6 +25,12 @@ PARSING_FUNCTION_REGEX = "set\\_(.)*\\_loop"
 BASE_TRANSACTION_PREFIX = "linuxforhealth.x12.v"
 
 
+class X12ParseException(Exception):
+    """Raised when an X12 unit of work such as a transaction or segment encounters a parsing error"""
+
+    pass
+
+
 def match(segment_name: str, conditions: Dict = None) -> Callable:
     """
     The match decorator matches a X12 segment to a decorated function.
@@ -248,7 +254,11 @@ class X12Parser(ABC):
         # drive the mapping with segment_fields as it includes all fields within the transactional context
         # field_names includes ALL available fields within the specification
         for index, value in enumerate(segment_fields):
-            field_name: str = field_names[index]
+            try:
+                field_name: str = field_names[index]
+            except IndexError as ie:
+                msg = f"Error parsing {segment_name} segment field {index}"
+                raise X12ParseException(msg)
 
             multivalue_separator: str = multivalue_fields.get(field_name)
             if multivalue_separator:

--- a/src/linuxforhealth/x12/v5010/segments.py
+++ b/src/linuxforhealth/x12/v5010/segments.py
@@ -1606,6 +1606,10 @@ class HiSegment(X12Segment):
     health_care_code_6: Optional[List] = Field(is_component=True)
     health_care_code_7: Optional[List] = Field(is_component=True)
     health_care_code_8: Optional[List] = Field(is_component=True)
+    health_care_code_9: Optional[List] = Field(is_component=True)
+    health_care_code_10: Optional[List] = Field(is_component=True)
+    health_care_code_11: Optional[List] = Field(is_component=True)
+    health_care_code_12: Optional[List] = Field(is_component=True)
 
 
 class HlSegment(X12Segment):

--- a/src/linuxforhealth/x12/v5010/x12_270_005010X279A1/segments.py
+++ b/src/linuxforhealth/x12/v5010/x12_270_005010X279A1/segments.py
@@ -29,7 +29,7 @@ class HeaderStSegment(StSegment):
     """
 
     transaction_set_identifier_code: Literal["270"]
-    implementation_convention_reference: Literal["005010X279A1"]
+    implementation_convention_reference: Literal["005010X279", "005010X279A1"]
 
 
 class HeaderBhtSegment(BhtSegment):

--- a/src/linuxforhealth/x12/v5010/x12_271_005010X279A1/segments.py
+++ b/src/linuxforhealth/x12/v5010/x12_271_005010X279A1/segments.py
@@ -31,7 +31,7 @@ class HeaderStSegment(StSegment):
     """
 
     transaction_set_identifier_code: Literal["271"]
-    implementation_convention_reference: Literal["005010X279A1"]
+    implementation_convention_reference: Literal["005010X279", "005010X279A1"]
 
 
 class HeaderBhtSegment(BhtSegment):

--- a/src/linuxforhealth/x12/v5010/x12_834_005010X220A1/segments.py
+++ b/src/linuxforhealth/x12/v5010/x12_834_005010X220A1/segments.py
@@ -30,7 +30,7 @@ class HeaderStSegment(StSegment):
     """
 
     transaction_set_identifier_code: Literal["834"]
-    implementation_convention_reference: Literal["005010X220A1"]
+    implementation_convention_reference: Literal["005010X220", "005010X220A1"]
 
 
 class HeaderRefSegment(RefSegment):

--- a/src/linuxforhealth/x12/v5010/x12_837_005010X222A2/segments.py
+++ b/src/linuxforhealth/x12/v5010/x12_837_005010X222A2/segments.py
@@ -1049,6 +1049,7 @@ class Loop2320SbrSegment(SbrSegment):
         """
         Code values for SBR09
         """
+
         OTHER_NON_FEDERAL_PROGRAMS = "11"
         PPO = "12"
         POS = "13"

--- a/src/linuxforhealth/x12/v5010/x12_837_005010X222A2/segments.py
+++ b/src/linuxforhealth/x12/v5010/x12_837_005010X222A2/segments.py
@@ -866,7 +866,7 @@ class Loop2310BNm1Segment(Nm1Segment):
     """
 
     entity_identifier_code: Literal["82"]
-    identification_code_qualifier: Literal["XX"]
+    identification_code_qualifier: Optional[Literal["XX"]]
 
 
 class Loop2310BPrvSegment(PrvSegment):

--- a/src/linuxforhealth/x12/v5010/x12_837_005010X222A2/segments.py
+++ b/src/linuxforhealth/x12/v5010/x12_837_005010X222A2/segments.py
@@ -1142,10 +1142,14 @@ class Loop2300BRefSegment(RefSegment):
         Code values for REF01
         """
 
-        PAYOR_IDENTIFICATION = "PI"
+        PAYOR_IDENTIFICATION_NUMBER = "2U"
         EMPLOYER_IDENTIFICATION_NUMBER = "EI"
         CLAIM_OFFICE_NUMBER = "FY"
         NAIC_CODE = "NF"
+        PRIOR_AUTHORIZATION_NUMBER = "G1"
+        REFERRAL_NUMBER = "9F"
+        SIGNAL_CODE = "T4"
+        ORIGINAL_REFERENCE_NUMBER = "F8"
 
     reference_identification_qualifier: ReferenceIdentificationQualifier
 

--- a/src/linuxforhealth/x12/v5010/x12_837_005010X222A2/segments.py
+++ b/src/linuxforhealth/x12/v5010/x12_837_005010X222A2/segments.py
@@ -210,6 +210,7 @@ class Loop2000BSbrSegment(SbrSegment):
     payer_responsibility_code: PayerResponsibilityCode
     individual_relationship_code: Optional[Literal["18"]]
     insurance_type_code: Optional[InsuranceTypeCode]
+    claim_filing_indicator_code: ClaimFilingIndicatorCode
 
 
 class Loop2000CHlSegment(HlSegment):
@@ -1044,9 +1045,38 @@ class Loop2320SbrSegment(SbrSegment):
         MEDICARE_SECONDARY_DISABLED_BENEFICIARY = "43"
         MEDICARE_SECONDARY_LIABILITY_PRIMARY = "47"
 
+    class ClaimFilingIndicatorCode(str, Enum):
+        """
+        Code values for SBR09
+        """
+        OTHER_NON_FEDERAL_PROGRAMS = "11"
+        PPO = "12"
+        POS = "13"
+        EPO = "14"
+        INDEMNITY_INSURANCE = "14"
+        HMO_MEDICARE_RISK = "16"
+        DENTAL_MAINTENANCE_ORGANIZATION = "17"
+        AUTOMOBILE_MEDICAL = "AM"
+        BLUE_CROSS_BLUE_SHIELD = "BL"
+        CHAMPUS = "CH"
+        COMMERCIAL_INSURANCE_CO = "CI"
+        DISABILITY = "DS"
+        FEDERAL_EMPLOYEE_PROGRAM = "FI"
+        HEALTH_MAINTENANCE_ORGANIZATION = "HM"
+        LIBABILITY_MEDICAL = "LM"
+        MEDICARE_PART_A = "MA"
+        MEDICARE_PART_B = "MB"
+        MEDICAID = "MC"
+        OTHER_FEDERAL_PROGRAM = "OF"
+        TITLE_V = "TV"
+        VETERANS_AFFAIR_PLAN = "VA"
+        WORKERS_COMPENSATION_HEALTH_CLAIM = "WC"
+        MUTUALLY_DEFINED = "ZZ"
+
     payer_responsibility_code: PayerResponsibilityCode
     individual_relationship_code: Optional[IndividualRelationshipCode]
-    claim_filing_indicator_code: InsuranceTypeCode
+    insurance_type_code: Optional[InsuranceTypeCode]
+    claim_filing_indicator_code: ClaimFilingIndicatorCode
 
 
 class Loop2330aNm1Segment(Nm1Segment):

--- a/src/linuxforhealth/x12/v5010/x12_837_005010X222A2/segments.py
+++ b/src/linuxforhealth/x12/v5010/x12_837_005010X222A2/segments.py
@@ -33,7 +33,9 @@ class HeaderStSegment(StSegment):
     """
 
     transaction_set_identifier_code: Literal["837"]
-    implementation_convention_reference: Literal["005010X222A2"]
+    implementation_convention_reference: Literal[
+        "005010X222", "005010X222A1", "005010X222A2"
+    ]
 
 
 class HeaderBhtSegment(BhtSegment):

--- a/src/linuxforhealth/x12/v5010/x12_837_005010X223A3/segments.py
+++ b/src/linuxforhealth/x12/v5010/x12_837_005010X223A3/segments.py
@@ -34,7 +34,9 @@ class HeaderStSegment(StSegment):
     """
 
     transaction_set_identifier_code: Literal["837"]
-    implementation_convention_reference: Literal["005010X223A3"]
+    implementation_convention_reference: Literal[
+        "005010X223", "005010X223A1", "005010X223A2", "005010X223A3"
+    ]
 
 
 class HeaderBhtSegment(BhtSegment):

--- a/src/tests/test_5010_segments.py
+++ b/src/tests/test_5010_segments.py
@@ -354,12 +354,21 @@ def test_hd_segment():
 
 def test_hi_segment():
     segment_data = {
-        "health_care_code_1": ["BK", "8901"],
-        "health_care_code_2": ["BF", "87200"],
-        "health_care_code_3": ["BF", "5559"],
+        "health_care_code_1": ["ABK", "M2578"],
+        "health_care_code_2": ["ABF", "M4802"],
+        "health_care_code_3": ["ABF", "M5023"],
+        "health_care_code_4": ["ABF", "M5136"],
+        "health_care_code_5": ["ABF", "M4126"],
+        "health_care_code_6": ["ABF", "M4316"],
+        "health_care_code_7": ["ABF", "M5416"],
+        "health_care_code_8": ["ABF", "M5030"],
+        "health_care_code_9": ["ABF", "M5412"],
     }
     hi_segment: HiSegment = HiSegment(**segment_data)
-    assert hi_segment.x12() == "HI*BK:8901*BF:87200*BF:5559~"
+    assert (
+        hi_segment.x12()
+        == "HI*ABK:M2578*ABF:M4802*ABF:M5023*ABF:M5136*ABF:M4126*ABF:M4316*ABF:M5416*ABF:M5030*ABF:M5412~"
+    )
 
 
 def test_hl_segment():


### PR DESCRIPTION
This PR updates the v5010 837P transaction following customer testing. Changes include:

-  Added missing reference codes to Loop 2330B
-  Updated codes for Loop 2320 SBR Claim Filing Indicator
-  Expanded HI segment to include optional health codes (up to 12)
-  Added reference codes for Loop 2130 NM1.08