### PR TITLE
Reinstating support for X12ModelReader Delimiter output

### DIFF
--- a/src/linuxforhealth/x12/io.py
+++ b/src/linuxforhealth/x12/io.py
@@ -137,14 +137,17 @@ class X12ModelReader:
           # do something interesting
     """
 
-    def __init__(self, x12_input: str) -> None:
+    def __init__(self, x12_input: str, output_delimiters: bool = False) -> None:
         """
         Initializes the X12ModelReader with a x12_input.
         The x12 input may be a message payload or a path to a x12 file.
 
         :param x12_input: The X12 Message or a path to a X12 file
+        :param output_delimiters: Set to True to include delimiter metadata in the model with each segment.
+            Defaults to False
         """
         self._x12_segment_reader: X12SegmentReader = X12SegmentReader(x12_input)
+        self.output_delimiters = output_delimiters
 
     def __enter__(self) -> "X12ModelReader":
         """
@@ -221,7 +224,9 @@ class X12ModelReader:
                     transaction_code, version, self._x12_segment_reader.delimiters
                 )
 
-            model: X12SegmentGroup = parser.parse(segment_name, segment_fields)
+            model: X12SegmentGroup = parser.parse(
+                segment_name, segment_fields, self.output_delimiters
+            )
             if model:
                 yield model
 

--- a/src/linuxforhealth/x12/models.py
+++ b/src/linuxforhealth/x12/models.py
@@ -6,7 +6,7 @@ Base models for X12 parsing and validation.
 import abc
 import datetime
 from enum import Enum
-from typing import List
+from typing import List, Optional
 from decimal import Decimal
 
 from pydantic import BaseModel, Field
@@ -123,6 +123,7 @@ class X12Segment(abc.ABC, BaseModel):
     X12BaseSegment serves as the abstract base class for all X12 segment models.
     """
 
+    delimiters: Optional[X12Delimiters] = None
     segment_name: X12SegmentName
 
     class Config:
@@ -166,7 +167,7 @@ class X12Segment(abc.ABC, BaseModel):
     def x12(self, custom_delimiters: X12Delimiters = None) -> str:
         """
         Generates a X12 formatted string for the segment.
-        By default the method will use default X12 delimiters. Custom delimiters may be specified if desired using
+        By default, the method will use default X12 delimiters. Custom delimiters may be specified if desired using
         the `custom_delimiters` parameter.
 
         :param custom_delimiters: Used when custom delimiters are required. Defaults to None.
@@ -175,7 +176,7 @@ class X12Segment(abc.ABC, BaseModel):
 
         delimiters = custom_delimiters or X12Delimiters()
         x12_values = []
-        for k, v in self.dict().items():
+        for k, v in self.dict(exclude={"delimiters"}).items():
             if isinstance(v, str):
                 x12_values.append(v)
             elif isinstance(v, list):

--- a/src/linuxforhealth/x12/parsing.py
+++ b/src/linuxforhealth/x12/parsing.py
@@ -283,7 +283,10 @@ class X12Parser(ABC):
         return self._transaction_model(**self._context.transaction_data)
 
     def parse(
-        self, segment_name: str, segment_fields: List[str]
+        self,
+        segment_name: str,
+        segment_fields: List[str],
+        output_delimiters: bool = False,
     ) -> Optional[X12SegmentGroup]:
         """
         Parses an X12 segment into the instance's data record attribute.
@@ -295,6 +298,8 @@ class X12Parser(ABC):
 
         :param segment_name: The name of the X12 segment (ST, HL, NM1, etc)
         :param segment_fields: List of segment field values
+        :param output_delimiters: Set to True to include delimiter metadata in the model with each segment.
+            Defaults to False
         :return: The X12 Transaction Model if ready, otherwise None.
         """
 
@@ -302,6 +307,8 @@ class X12Parser(ABC):
 
         # convert segment data to a dictionary "record"
         segment_data: Dict = self._parse_segment(segment_name, segment_fields)
+        if output_delimiters:
+            segment_data["delimiters"] = self._delimiters.dict()
 
         if segment_name.lower() == "hl":
             self._context.hl_segment = segment_data

--- a/src/tests/test_x12_model_reader.py
+++ b/src/tests/test_x12_model_reader.py
@@ -4,7 +4,9 @@ test_x12_model_reader.py
 Supports general model streaming tests validating the number of models returned, expected payload, etc.
 """
 from linuxforhealth.x12.io import X12ModelReader
-from linuxforhealth.x12.models import X12Delimiters
+from linuxforhealth.x12.models import X12Delimiters, X12SegmentGroup
+from typing import Dict, List
+import pytest
 
 
 def test_multiple_transactions(large_x12_message):
@@ -14,7 +16,14 @@ def test_multiple_transactions(large_x12_message):
         assert len(model_result) == 10
 
 
-def test_custom_delimiters(x12_with_custom_delimiters):
+@pytest.mark.parametrize("output_delimiters", [True, False])
+def test_custom_delimiters(x12_with_custom_delimiters, output_delimiters):
+    """
+    Validates that custom delimiters are parsed correctly and generate expected x12
+
+    :param x12_with_custom_delimiters: The X12 sample transaction
+    :param output_delimiters:
+    """
 
     # remove control segments from the x12 transaction with custom delimiters
     control_segments = ("ISA", "GS", "GE", "IEA")
@@ -28,10 +37,51 @@ def test_custom_delimiters(x12_with_custom_delimiters):
 
     expected_transaction = "\n".join(expected_segments)
 
-    with X12ModelReader(x12_with_custom_delimiters) as r:
+    with X12ModelReader(
+        x12_with_custom_delimiters, output_delimiters=output_delimiters
+    ) as r:
         model_result = [m for m in r.models()]
         assert len(model_result) == 1
-        assert (
-            model_result[0].x12(custom_delimiters=x12_delimiters)
-            == expected_transaction
-        )
+        model = model_result[0]
+        assert model.x12(custom_delimiters=x12_delimiters) == expected_transaction
+
+    # validate custom delimiter handling based on the output_delimiters flag
+    st_segment = model.header.st_segment
+    if output_delimiters:
+        assert st_segment.delimiters.element_separator == "|"
+        assert st_segment.delimiters.repetition_separator == "^"
+        assert st_segment.delimiters.component_separator == ":"
+        assert st_segment.delimiters.segment_terminator == "?"
+    else:
+        assert st_segment.delimiters is None
+
+
+def _assert_delimiters(data: Dict, delimiters_exist: bool):
+    """
+    Parameterized helper function for test_output_delimiters.
+    The function recursively examines a X12 transaction dictionary and executes
+    assertions testing for the existence or absence of delimiters within a X12 segment dictionary.
+
+    :param data: The X12 data dictionary
+    :param delimiters_exist: When True assertions check for delimiter existence.
+    """
+    for k, v in data.items():
+        if k.endswith("segment") and delimiters_exist:
+            assert v["delimiters"]
+        elif k.endswith("segment") and not delimiters_exist:
+            assert v.get("delimiters") is None
+        elif isinstance(v, dict):
+            _assert_delimiters(v, delimiters_exist)
+
+
+@pytest.mark.parametrize("output_delimiters", [True, False])
+def test_output_delimiters(simple_270_with_new_lines, output_delimiters):
+    """Tests the X12ModelReader output_delimiter flag"""
+    with X12ModelReader(
+        simple_270_with_new_lines, output_delimiters=output_delimiters
+    ) as r:
+        model_result: List[X12SegmentGroup] = [m for m in r.models()]
+        assert len(model_result) == 1
+
+        model_data = model_result[0].dict()
+        _assert_delimiters(model_data, output_delimiters)


### PR DESCRIPTION
This PR reinstates support for including delimiter metadata within the X12Model, based on user feedback. This feature was removed in #113 .

  Rather than revert the commit, I opted to “reimplement” delimiter support in a way that wasn’t as tightly coupled as the previous implementation. Changes made to support optional delimiter inclusion include:  
  
  - Added boolean output_delimiter attribute to the X12ModelReader. This param determines if the delimiter metadata is included on a model. 
  - X12ModelReader passes output_delimiter to the X12Parser’s parse method 
  - CLI is updated to include a “-d” flag which will include delimiter data 
  - test_x12_model_reader includes parameterized tests for the output_delimiter change  
  
  To include delimiters in a model simply set output_delimiters to True 
  
```python
   from linuxforhealth.x12.io import X12ModelReader  
   
   with X12ModelReader(“file.x12”, output_delimiters=True) as r: 
     for m in r.models():   
       # interesting code goes here
```

`output_delimiters` defaults to False, so this feature is “opt-in”

  To view delimiters within the CLI output 
```shell
(venv) mbp x12 % lfhx12 -m -p -d demo.cob.example4.837
[
    {
        "header": {
            "st_segment": {
                "delimiters": {
                    "element_separator": "*",
                    "repetition_separator": "^",
                    "segment_terminator": "~",
                    "component_separator": ":"
                },
                "segment_name": "ST",
                "transaction_set_identifier_code": "837",
                "transaction_set_control_number": "0002",
                "implementation_convention_reference": "005010X222A2"
            },
            <etc>
 	}
] 
```
closes #114 
Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>