### PR TITLE
Align /x12 [POST] "segment" API response with CLI

### DIFF
--- a/src/linuxforhealth/x12/api.py
+++ b/src/linuxforhealth/x12/api.py
@@ -69,7 +69,13 @@ async def post_x12(
                 api_results = [m.dict() for m in r.models()]
         else:
             with X12SegmentReader(x12_request.x12) as r:
-                api_results = [s for s in r.segments()]
+                api_results = []
+                for segment_name, segment in r.segments():
+                    segment_data = {
+                        f"{segment_name}{str(i).zfill(2)}": v
+                        for i, v in enumerate(segment)
+                    }
+                    api_results.append(segment_data)
 
     except (X12ParseException, ValidationError) as error:
         raise HTTPException(

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -33,19 +33,15 @@ def mock_x12_payload(simple_270_with_new_lines: str) -> Dict:
 @pytest.mark.parametrize(
     "header, expected_first_value",
     [
-        # the response payload and resulting "first value" varies based on the request header
         (None, "header"),
         ("models", "header"),
         ("Models", "header"),
         ("MODELS", "header"),
-        ("segments", "ISA"),
-        ("Segments", "ISA"),
-        ("SEGMENTS", "ISA"),
     ],
 )
-def test_x12_ok(mock_x12_payload, api_test_client, header, expected_first_value):
+def test_x12_ok_models(mock_x12_payload, api_test_client, header, expected_first_value):
     """
-    Tests the x12 segment response with parameterized header and expected values.
+    Tests the x12 models response with parameterized header and expected values.
     :param mock_x12_payload: The X12 request payload for the test
     :param api_test_client: The configured Fast API test client
     :param header: The parameterized header value
@@ -56,6 +52,30 @@ def test_x12_ok(mock_x12_payload, api_test_client, header, expected_first_value)
     )
     assert api_response.status_code == 200
     assert expected_first_value in api_response.json()[0]
+
+
+@pytest.mark.skipif(is_fastapi_disabled, reason="X12 API endpoint is not enabled")
+@pytest.mark.parametrize(
+    "header, expected_key",
+    [
+        ("segments", "ISA01"),
+        ("Segments", "ISA01"),
+        ("SEGMENTS", "ISA01"),
+    ],
+)
+def test_x12_ok_segments(mock_x12_payload, api_test_client, header, expected_key):
+    """
+    Tests the x12 segments response with parameterized header and expected values.
+    :param mock_x12_payload: The X12 request payload for the test
+    :param api_test_client: The configured Fast API test client
+    :param header: The parameterized header value
+    :param expected_key: The parameterized expected key
+    """
+    api_response = api_test_client.post(
+        "/x12", json=mock_x12_payload, headers={"LFH-X12-RESPONSE": header}
+    )
+    assert api_response.status_code == 200
+    assert expected_key in api_response.json()[0].keys()
 
 
 @pytest.mark.skipif(is_fastapi_disabled, reason="X12 API endpoint is not enabled")


### PR DESCRIPTION
This PR updates the `/x12 [POST]` endpoint to return a segment response which aligns with x12 CLI segment.

closes #128 

Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>