### PR TITLE
status endpoint

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ 0.58.0 ]
 
 jobs:
   build:

--- a/.github/workflows/test-image-build.yml
+++ b/.github/workflows/test-image-build.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           context: .
           build-args: |
-            X12_SEM_VER=0.57.0
+            X12_SEM_VER=0.58.0
           platforms: linux/amd64
           push: false
           tags: ci-testing

--- a/.github/workflows/test-image-build.yml
+++ b/.github/workflows/test-image-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ 0.58.0 ]
 
 jobs:
   build-image:

--- a/src/linuxforhealth/x12/api.py
+++ b/src/linuxforhealth/x12/api.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional, List
 from linuxforhealth.x12.config import get_x12_api_config, X12ApiConfig
 from linuxforhealth.x12.io import X12SegmentReader, X12ModelReader
 from linuxforhealth.x12.parsing import X12ParseException
+from linuxforhealth.x12 import __version__
 from pydantic import ValidationError, BaseModel, Field
 
 app = FastAPI()
@@ -84,6 +85,14 @@ async def post_x12(
         )
     else:
         return api_results
+
+
+@app.get("/status")
+def get_status():
+    return {
+        "version": __version__,
+        "status": "ok",
+    }
 
 
 def run_server():

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -94,3 +94,14 @@ def test_x12_invalid_request(api_test_client, mock_x12_payload):
     invalid_payload = {"x12": invalid_x12}
     api_response = api_test_client.post("/x12", json=invalid_payload)
     assert api_response.status_code == 400
+
+
+@pytest.mark.skipif(is_fastapi_disabled, reason="X12 API endpoint is not enabled")
+def test_status_request(api_test_client, mock_x12_payload):
+    """
+    Validates that invalid
+    :param api_test_client: The configured Fast API test client
+    :param mock_x12_payload: The X12 request payload for the test
+    """
+    api_response = api_test_client.get("/status")
+    assert api_response.status_code == 200


### PR DESCRIPTION
This PR implements the /status endpoint used to confirm service availability.
closes #137 
Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>